### PR TITLE
refactor(reducers): Use better pattern to import/export reducers.

### DIFF
--- a/src/app/models/users.ts
+++ b/src/app/models/users.ts
@@ -6,17 +6,15 @@ import { normalize, arrayOf, Schema } from 'normalizr';
 import { List, Map, Record, fromJS } from 'immutable';
 import {ApiService} from '../modules/api';
 
-import {
-  LOADING_USERS,
-  LOADED_USERS,
-  LOADING_USER,
-  LOADED_USER,
-  ADDING_USER,
-  ADDED_USER,
-  DELETING_USER,
-  DELETED_USER,
-  PATCHED_USER
-} from '../reducers/users';
+export const LOADING_USERS = 'LOADING_USERS';
+export const LOADED_USERS = 'LOADED_USERS';
+export const LOADING_USER = 'LOADING_USER';
+export const LOADED_USER = 'LOADED_USER';
+export const ADDING_USER = 'ADDING_USER';
+export const ADDED_USER = 'ADDED_USER';
+export const DELETING_USER = 'DELETING_USER';
+export const DELETED_USER = 'DELETED_USER';
+export const PATCHED_USER = 'PATCHED_USER';
 
 const PATCH_USER = 'PATCH_USER';
 const DELETE_USER = 'DELETE_USER';

--- a/src/app/reducers/index.ts
+++ b/src/app/reducers/index.ts
@@ -1,0 +1,1 @@
+export * from './users';

--- a/src/app/reducers/users.ts
+++ b/src/app/reducers/users.ts
@@ -4,15 +4,17 @@ import { normalize, arrayOf, Schema } from 'normalizr';
 
 import { IUser, IUsers, userSchema, UserRecord } from '../models/users';
 
-export const LOADING_USERS = 'LOADING_USERS';
-export const LOADED_USERS = 'LOADED_USERS';
-export const LOADING_USER = 'LOADING_USER';
-export const LOADED_USER = 'LOADED_USER';
-export const ADDING_USER = 'ADDING_USER';
-export const ADDED_USER = 'ADDED_USER';
-export const DELETING_USER = 'DELETING_USER';
-export const DELETED_USER = 'DELETED_USER';
-export const PATCHED_USER = 'PATCHED_USER';
+import {
+  LOADING_USERS,
+  LOADED_USERS,
+  LOADING_USER,
+  LOADED_USER,
+  ADDING_USER,
+  ADDED_USER,
+  DELETING_USER,
+  DELETED_USER,
+  PATCHED_USER
+} from '../models/users';
 
 var initialState: IUsers = fromJS({
   result: [],
@@ -20,8 +22,7 @@ var initialState: IUsers = fromJS({
     users: {}
   },
   adding: false,
-  loading: false,
-  currentDetailId: null
+  loading: false
 });
 
 export const users: Reducer<any> = (state = initialState, action: Action) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,7 @@ import {ROUTER_PROVIDERS, LocationStrategy, HashLocationStrategy} from 'angular2
 import {HTTP_PROVIDERS} from 'angular2/http';
 
 import {provideStore} from '@ngrx/store';
-import {Users} from './app/models/users';
-import {users} from './app/reducers/users';
+import * as reducers from './app/reducers/index';
 import {API_PROVIDERS} from './app/modules/api';
 
 /*
@@ -27,7 +26,7 @@ document.addEventListener('DOMContentLoaded', function main() {
     HTTP_PROVIDERS,
     ROUTER_PROVIDERS,
     provide(LocationStrategy, { useClass: HashLocationStrategy }),
-    provideStore({ users }),
+    provideStore(reducers),
     API_PROVIDERS
   ])
   .catch(err => console.error(err));


### PR DESCRIPTION
This addresses #10.  The TypeScript complier has an issue with this though.  @robwormald: Would you know why?  The error is:
```
ERROR in ./src/main.ts
(29,18): error TS2345: Argument of type 'typeof "/Users/codyl/dev-files/angular2-store-example/src/app/reducers/index"' is not assignable to parameter of type '{ [key: string]: Reducer<any>; }'.
  Index signature is missing in type 'typeof "/Users/codyl/dev-files/angular2-store-example/src/app/reducers/index"'.
```