### PR TITLE
chore(tslint): Update to trailing-comma

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -20,7 +20,7 @@
     "no-duplicate-variable": true,
     "no-empty": false,
     "no-eval": true,
-    "no-trailing-comma": true,
+    "trailing-comma": false,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-unused-variable": false,


### PR DESCRIPTION
no-trailing-comma rule removed, it is replaced by the trailing-comma rule

https://github.com/palantir/tslint/pull/687